### PR TITLE
Add Config Editor learning materials page

### DIFF
--- a/src/pages/configeditor/learning_materials.md
+++ b/src/pages/configeditor/learning_materials.md
@@ -1,0 +1,57 @@
+---
+title: "Learning Materials"
+excerpt: "Learning Materials"
+categories: configeditor
+slug: learning_materials
+toc: true
+---
+<!-- ---
+
+copyright:
+  years: 2022
+lastupdated: "2022-10-07"
+
+keywords: configuration editor, learning, education, 
+
+subcollection: wh-acd
+
+--- -->
+
+<!-- # Learning Material -->
+
+Videos and links to educational content about Annotator for Clinical Data Configuration Editor.
+
+*Note: Our name changed since these videos were recorded. The features are still the same.*
+
+- ### [Annotator for Clinical Data Configuration Editor and UMLS Overview](https://ibm.box.com/s/hrq96sis1std0yo1z76nnuzt88h0czpg) (11 min)
+    Provides an overview of the Annotator for Clinical Data Configuration Editor and UMLS, which is included with the Configuration Editor.
+- ### [Introduction to Concepts](https://ibm.box.com/s/ddplnpjqdccasux02mauxiak31758glz) (10 min)
+    Explains how to create, edit, delete concepts and view text analysis results.
+- ### [Introduction to Clinical Attributes](https://ibm.box.com/s/nd33ana5pnfsubdyjx6kuoi92d9vlml2) (10 min) 
+    Explains how to create, edit clinical attribute sets and view text analysis results.  
+- ### [Introduction to Filter](https://ibm.box.com/s/bohf1rp44hofpmzj9wu27oc1flw23hoi) (5 min)
+    Explains how to create and edit a filter artifact.
+- ### [Preview analytic results](https://ibm.box.com/s/r6rl7s1lq08ngyg1kydx3fymtrfyls6r) (14 min)
+    Explains how to preview analyze results, compare two results and save sample text with the cartridge.
+- ### [Derived Concepts](https://ibm.box.com/s/j91ak6shkc9yv55nb1nk9y18edxkz0qg) (18 min)
+    Explains how to create derived concepts.
+- ### [Derived Clinical Attributes](https://ibm.box.com/s/xl43p1cc4dgql7b7gehhwp4th4due3vt) (12 min)
+    Explains how to create derived clinical attributes.
+- ### [Qualifiers](https://ibm.box.com/s/zsfqzwis2dltzlv7rfxfyav7kd9w2oj7) (6 min) 
+    Explains how to create and use attribute qualifiers.
+- ### [Custom Value and Custom Comparison](https://ibm.box.com/s/3c7o5wyyzx9az91r1a0leepzah4m6jyj)  (13 min) 
+    Explains how to create, edit and use a custom value and custom comparison artifacts.
+- ### [Care Insights Annotators](https://ibm.box.com/s/xjo5ke6ftrjwjnd4uehshgsnbb3yis52)  (12 min)
+    Explains how to use, interpret, and customize the Care Insights annotators available in the Annotator for Clinical Data.
+- ### [Contextual Annotators](https://ibm.box.com/s/dl6ul4d6k7wh309v972r3s1291ldb26y) (9 min)
+    Explains how to use and interpret the Contextual annotators.
+- ### [Publish, Deploy and Analyze API](https://ibm.box.com/s/2q3zoiym45kcsm52alkkp8s23ppkndzi)  (8 min) 
+    Explains how to publish a cartridge, deploy it to Annotator for Clinical Data service and how to call the Annotator for Clinical Data API using the deployed cartridge to analyze unstructured text. 
+- ### [Ontology and Relationship Configuration Overview](https://ibm.box.com/s/rrsoqao128phlx7oadizio2gnjmubsni)  (21 min) 
+    Explains how to create custom ontologies to define relationships between custom concepts. Also covers using custom ontologies and UMLS to explore and detect relationships between concepts.
+- ### [Extending ACD Clinical Insights](https://ibm.box.com/s/3s4mjlc6pkykkqt5lo3wsz262xy12ef3) (25 min)
+    Introduces the ACD Clinical Insights cartridge and explains how to extend the cartridge and customize it.
+    - Introduction (0 - 4:56 min)
+    - Extending the ACD Clinical Insights cartridge (4:57 - 7:44 min)
+    - Customizing the ACD Clinical Insights attributes (7:45 - 24:48 min) 
+

--- a/src/pages/configeditor/overview.md
+++ b/src/pages/configeditor/overview.md
@@ -45,6 +45,9 @@ The Configuration Editor can be deployed locally to a single Linux system using 
 
 Once installed, use the instructions on the Install page to access the Configuration Editor using a browser on the host it was deployed to.
 
+### Learning Materials
+Videos and other [educational content](/configeditor/learning_materials).
+
 ### Support and Questions
 Configuration Editor is provided to you as-is and free of charge.  Please use your IBM contact email and/or the interlock Slack channel, if provided, to ask questions.
 


### PR DESCRIPTION
Signed-off-by: Brian <bcragun@merative.com>

Adds a Learning Materials page, and a link to it on the Configuration Editor overview page

Set for URL: https://merative.github.io/acd-containers/configeditor/learning_materials/