### PR TITLE
Correct the Procedure Link

### DIFF
--- a/src/pages/clouddocs/clinical_insights_overview.md
+++ b/src/pages/clouddocs/clinical_insights_overview.md
@@ -31,7 +31,7 @@ You can use the Annotator for Clinical Data Configuration Editor to [customize a
 Each model contributes contextual features to annotations that are either produced by standard Annotator for Clinical Data annotators or from custom annotations you create using the Annotator for Clinical Data Configuration Editor.  The Clinical Insights Models include:
 
 1. [Medication](/clouddocs/clinical_insights_medication/)
-2. [Procedure](/clouddocs/annotator_procedure/)
+2. [Procedure](/clouddocs/clinical_insights_procedure/)
 3. [Diagnosis](/clouddocs/clinical_insights_diagnosis/)
 4. [Normality - Experimental](/clouddocs/clinical_insights_normality/)
 5. [Temporal - Experimental](/clouddocs/temporal_overview/)


### PR DESCRIPTION
The procedure link was pointing to the procedure annotator instead of the clinical insights procedure model.