### PR TITLE
Remove extraneous double quotes

### DIFF
--- a/static/apidocs/index.html
+++ b/static/apidocs/index.html
@@ -671,7 +671,7 @@
 <blockquote>
 <p>Code samples</p>
 </blockquote>
-<div class="highlight"><pre class="highlight shell tab-shell"><code>curl <span class="nt">-X</span> POST<span class="s2">" </span><span class="se">\</span><span class="s2">
+<div class="highlight"><pre class="highlight shell tab-shell"><code>curl <span class="nt">-X</span> POST<span class="s2"> </span><span class="se">\</span><span class="s2">
 --header "</span>Content-Type: application/json<span class="s2">" </span><span class="se">\</span><span class="s2">
 --header "</span>Accept: application/json<span class="s2">" </span><span class="se">\</span><span class="s2">
 --header "</span>Authorization: Bearer <span class="o">{</span>token<span class="o">}</span><span class="s2">" </span><span class="se">\</span><span class="s2">
@@ -1010,7 +1010,7 @@
 <blockquote>
 <p>Code samples</p>
 </blockquote>
-<div class="highlight"><pre class="highlight shell tab-shell"><code>curl <span class="nt">-X</span> PUT<span class="s2">" </span><span class="se">\</span><span class="s2">
+<div class="highlight"><pre class="highlight shell tab-shell"><code>curl <span class="nt">-X</span> PUT<span class="s2"> </span><span class="se">\</span><span class="s2">
 --header "</span>Content-Type: application/json<span class="s2">" </span><span class="se">\</span><span class="s2">
 --header "</span>Accept: application/json<span class="s2">" </span><span class="se">\</span><span class="s2">
 --header "</span>Authorization: Bearer <span class="o">{</span>token<span class="o">}</span><span class="s2">" </span><span class="se">\</span><span class="s2">
@@ -1450,7 +1450,7 @@
 <blockquote>
 <p>Code samples</p>
 </blockquote>
-<div class="highlight"><pre class="highlight shell tab-shell"><code>curl <span class="nt">-X</span> POST<span class="s2">" </span><span class="se">\</span><span class="s2">
+<div class="highlight"><pre class="highlight shell tab-shell"><code>curl <span class="nt">-X</span> POST<span class="s2"> </span><span class="se">\</span><span class="s2">
 --header "</span>Content-Type: application/json<span class="s2">" </span><span class="se">\</span><span class="s2">
 --header "</span>Accept: application/json<span class="s2">" </span><span class="se">\</span><span class="s2">
 --header "</span>Authorization: Bearer <span class="o">{</span>token<span class="o">}</span><span class="s2">" </span><span class="se">\</span><span class="s2">
@@ -1852,7 +1852,7 @@
 <blockquote>
 <p>Code samples</p>
 </blockquote>
-<div class="highlight"><pre class="highlight shell tab-shell"><code>curl <span class="nt">-X</span> PUT<span class="s2">" </span><span class="se">\</span><span class="s2">
+<div class="highlight"><pre class="highlight shell tab-shell"><code>curl <span class="nt">-X</span> PUT<span class="s2"> </span><span class="se">\</span><span class="s2">
 --header "</span>Content-Type: application/json<span class="s2">" </span><span class="se">\</span><span class="s2">
 --header "</span>Accept: application/json<span class="s2">" </span><span class="se">\</span><span class="s2">
 --header "</span>Authorization: Bearer <span class="o">{</span>token<span class="o">}</span><span class="s2">" </span><span class="se">\</span><span class="s2">
@@ -2349,7 +2349,7 @@
 <blockquote>
 <p>Code samples</p>
 </blockquote>
-<div class="highlight"><pre class="highlight shell tab-shell"><code>curl <span class="nt">-X</span> POST<span class="s2">" </span><span class="se">\</span><span class="s2">
+<div class="highlight"><pre class="highlight shell tab-shell"><code>curl <span class="nt">-X</span> POST<span class="s2"> </span><span class="se">\</span><span class="s2">
 --header "</span>Content-Type: application/octet-stream<span class="s2">" </span><span class="se">\</span><span class="s2">
 --header "</span>Accept: application/json<span class="s2">" </span><span class="se">\</span><span class="s2">
 --header "</span>Authorization: Bearer <span class="o">{</span>token<span class="o">}</span><span class="s2">" </span><span class="se">\</span><span class="s2">
@@ -2513,7 +2513,7 @@
 <blockquote>
 <p>Code samples</p>
 </blockquote>
-<div class="highlight"><pre class="highlight shell tab-shell"><code>curl <span class="nt">-X</span> PUT<span class="s2">" </span><span class="se">\</span><span class="s2">
+<div class="highlight"><pre class="highlight shell tab-shell"><code>curl <span class="nt">-X</span> PUT<span class="s2"> </span><span class="se">\</span><span class="s2">
 --header "</span>Content-Type: application/octet-stream<span class="s2">" </span><span class="se">\</span><span class="s2">
 --header "</span>Accept: application/json<span class="s2">" </span><span class="se">\</span><span class="s2">
 --header "</span>Authorization: Bearer <span class="o">{</span>token<span class="o">}</span><span class="s2">" </span><span class="se">\</span><span class="s2">
@@ -2908,7 +2908,7 @@
 <blockquote>
 <p>Code samples</p>
 </blockquote>
-<div class="highlight"><pre class="highlight shell tab-shell"><code>curl <span class="nt">-X</span> POST<span class="s2">" </span><span class="se">\</span><span class="s2">
+<div class="highlight"><pre class="highlight shell tab-shell"><code>curl <span class="nt">-X</span> POST<span class="s2"> </span><span class="se">\</span><span class="s2">
 --header "</span>Content-Type: application/octet-stream<span class="s2">" </span><span class="se">\</span><span class="s2">
 --header "</span>Accept: application/json<span class="s2">" </span><span class="se">\</span><span class="s2">
 --header "</span>Authorization: Bearer <span class="o">{</span>token<span class="o">}</span><span class="s2">" </span><span class="se">\</span><span class="s2">
@@ -3202,7 +3202,7 @@
 <blockquote>
 <p>Code samples</p>
 </blockquote>
-<div class="highlight"><pre class="highlight shell tab-shell"><code>curl <span class="nt">-X</span> POST<span class="s2">" </span><span class="se">\</span><span class="s2">
+<div class="highlight"><pre class="highlight shell tab-shell"><code>curl <span class="nt">-X</span> POST<span class="s2"> </span><span class="se">\</span><span class="s2">
 --header "</span>Content-Type: application/json<span class="s2">" </span><span class="se">\</span><span class="s2">
 --header "</span>Accept: application/json<span class="s2">" </span><span class="se">\</span><span class="s2">
 --header "</span>Authorization: Bearer <span class="o">{</span>token<span class="o">}</span><span class="s2">" </span><span class="se">\</span><span class="s2">


### PR DESCRIPTION
Remove extraneous double quotes on API call examples